### PR TITLE
tail: -F now always processes initially untailable files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,11 @@ GNU coreutils NEWS                                    -*- outline -*-
   seq now immediately exits upon write errors.
   [This bug was present in "the beginning".]
 
+  tail -F now continues to process initially untailable files that are replaced
+  by a tailable file.  This was handled correctly when inotify was available,
+  and is now handled correctly in all cases.
+  [bug introduced in fileutils-4.0h]
+
   yes now handles short writes, rather than assuming all writes complete.
   [bug introduced in coreutils-8.24]
 

--- a/THANKS.in
+++ b/THANKS.in
@@ -330,6 +330,7 @@ Josselin Mouette                    joss@debian.org
 Juan F. Codagnone                   juam@arnet.com.ar
 Juan M. Guerrero                    st001906@hrz1.hrz.tu-darmstadt.de
 Julian Bradfield                    jcb@inf.ed.ac.uk
+Julian Büning                       julian.buening@rwth-aachen.de
 Jungshik Shin                       jshin@pantheon.yale.edu
 Juraj Marko                         jmarko@redhat.com
 Jürgen Fluk                         louis@dachau.marco.de


### PR DESCRIPTION
which was not the case when inotify was not available.
- src/tail.c (any_live_files): Simplify, since the IGNORE
  flag is now only set when a file should be ignored indefinitely.
  (recheck): Only output the "giving up on name" message
  when that's actually the case.  Only set the IGNORE flag
  when ignoring a file indefinitely.
  (tail_file): Likewise.
- tests/tail-2/retry.sh: Add a test case.  Also run
  all existing test cases with and without inotify.
  NEWS: Mention the fix.
  THANKS.in: Add the reporter.
  Fixes http://bugs.gnu.org/24495 which was detected
  using Symbolic Execution techniques developed in
  the course of the SYMBIOSYS research project at
  COMSYS, RWTH Aachen University.
